### PR TITLE
Add minimal Flask kanban prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# BDWGPT
+# TechBuy Buildroom Prototype
+
+This repository contains a minimal prototype for a digital kanban board and
+system checklist used by the TechBuy buildroom. It allows tracking of orders
+and per-system checklist steps.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Initialize the database:
+
+```bash
+flask --app app.py initdb
+```
+
+3. Run the development server:
+
+```bash
+flask --app app.py run
+```
+
+The application will be available at `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,14 @@
+from app import create_app, db
+from app.models import Order, System, ChecklistItem
+
+app = create_app()
+
+
+@app.cli.command('initdb')
+def initdb():
+    db.create_all()
+    print('Database initialized.')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,21 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+
+
+db = SQLAlchemy()
+migrate = Migrate()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+
+    from .routes import main as main_blueprint
+    app.register_blueprint(main_blueprint)
+
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from . import db
+
+
+class Order(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    customer = db.Column(db.String(128))
+    status = db.Column(db.String(64), default='Ordered')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    systems = db.relationship('System', backref='order', lazy=True)
+
+
+class System(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    order_id = db.Column(db.Integer, db.ForeignKey('order.id'))
+    name = db.Column(db.String(128))
+    serial_number = db.Column(db.String(128))
+    checklist_items = db.relationship('ChecklistItem', backref='system', lazy=True)
+
+
+class ChecklistItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    system_id = db.Column(db.Integer, db.ForeignKey('system.id'))
+    description = db.Column(db.String(256))
+    completed = db.Column(db.Boolean, default=False)
+    qa_checked = db.Column(db.Boolean, default=False)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, render_template, redirect, url_for, request
+
+from . import db
+from .models import Order, System, ChecklistItem
+
+main = Blueprint('main', __name__)
+
+
+@main.route('/')
+def index():
+    orders = Order.query.all()
+    statuses = ['Ordered', 'In progress', 'Ready to deliver', 'Complete']
+    return render_template('index.html', orders=orders, statuses=statuses)
+
+
+@main.route('/order/<int:order_id>')
+def view_order(order_id):
+    order = Order.query.get_or_404(order_id)
+    return render_template('order.html', order=order)
+
+
+@main.route('/order/<int:order_id>/move', methods=['POST'])
+def move_order(order_id):
+    order = Order.query.get_or_404(order_id)
+    status = request.form.get('status')
+    order.status = status
+    db.session.commit()
+    return redirect(url_for('main.index'))
+
+
+@main.route('/system/<int:system_id>/check', methods=['POST'])
+def check_item(system_id):
+    item_id = request.form.get('item_id')
+    item = ChecklistItem.query.get_or_404(item_id)
+    if request.form.get('action') == 'complete':
+        item.completed = not item.completed
+    elif request.form.get('action') == 'qa':
+        item.qa_checked = not item.qa_checked
+    db.session.commit()
+    return redirect(url_for('main.view_order', order_id=item.system.order_id))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <title>TechBuy Buildroom</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .column { float: left; width: 24%; padding: 10px; border: 1px solid #ccc; margin-right: 1%; }
+        .order { background: #f7f7f7; padding: 5px; margin-bottom: 5px; }
+        .clearfix::after { content: ""; clear: both; display: table; }
+    </style>
+</head>
+<body>
+    <h1>TechBuy Buildroom</h1>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="clearfix">
+    {% for status in statuses %}
+    <div class="column">
+        <h3>{{ status }}</h3>
+        {% for order in orders if order.status == status %}
+            <div class="order">
+                <a href="{{ url_for('main.view_order', order_id=order.id) }}">Order {{ order.id }} - {{ order.customer }}</a>
+                <form action="{{ url_for('main.move_order', order_id=order.id) }}" method="post">
+                    <select name="status" onchange="this.form.submit()">
+                        {% for s in statuses %}
+                        <option value="{{ s }}" {% if s == order.status %}selected{% endif %}>{{ s }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </div>
+        {% endfor %}
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/order.html
+++ b/app/templates/order.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Order {{ order.id }} - {{ order.customer }}</h2>
+<p>Status: {{ order.status }}</p>
+<a href="{{ url_for('main.index') }}">Back to board</a>
+
+{% for system in order.systems %}
+    <h3>{{ system.name }} {% if system.serial_number %}({{ system.serial_number }}){% endif %}</h3>
+    <ul>
+    {% for item in system.checklist_items %}
+        <li>
+            <form action="{{ url_for('main.check_item', system_id=system.id) }}" method="post" style="display:inline;">
+                <input type="hidden" name="item_id" value="{{ item.id }}">
+                <button name="action" value="complete" type="submit">{% if item.completed %}✔{% else %}✗{% endif %}</button>
+                {{ item.description }}
+            </form>
+            <form action="{{ url_for('main.check_item', system_id=system.id) }}" method="post" style="display:inline;">
+                <input type="hidden" name="item_id" value="{{ item.id }}">
+                <button name="action" value="qa" type="submit">QA {% if item.qa_checked %}✔{% else %}✗{% endif %}</button>
+            </form>
+        </li>
+    {% endfor %}
+    </ul>
+{% endfor %}
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.2.5
+Flask-SQLAlchemy==3.0.5
+Flask-Migrate==4.0.4


### PR DESCRIPTION
## Summary
- implement Flask app with SQLite models for orders and checklists
- provide routes and templates for a basic kanban board and per-system checklist view
- document setup and usage in README

## Testing
- `python -m py_compile app.py app/__init__.py app/models.py app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68519b1e07788330961f5eef280a6f67